### PR TITLE
[NEEDS TESTING] Fix ImportError caused by importing `src.info` before checking dependencies.

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,8 +3,6 @@
 if __name__ == "__main__":
     import sys
     from src.util.missing_dep import Requirements, REQUIRED
-    from src.info import color_text
-    from src.cli.ui import clear as clear_screen
     if sys.version_info < (3, 8, 0):
         print(color_text("OCSysInfo requires Python 3.8, while Python " + str(
             sys.version.partition(" ")[0]) + " was detected. Terminating... ", "red")
@@ -27,8 +25,9 @@ if __name__ == "__main__":
             exit(0)
 
     import requests
-
-    # requests is being importing here because it will error out
+    from src.info import color_text
+    from src.cli.ui import clear as clear_screen
+    # requests clear_screen, and color_text are being importing here because the program will error out
     # if there are missing dependencies in the start of the program
 
     try:

--- a/main.py
+++ b/main.py
@@ -4,9 +4,8 @@ if __name__ == "__main__":
     import sys
     from src.util.missing_dep import Requirements, REQUIRED
     if sys.version_info < (3, 8, 0):
-        print(color_text("OCSysInfo requires Python 3.8, while Python " + str(
-            sys.version.partition(" ")[0]) + " was detected. Terminating... ", "red")
-              )
+        print("OCSysInfo requires Python 3.8, while Python " + str(
+            sys.version.partition(" ")[0]) + " was detected. Terminating... ")
         sys.exit(1)
 
     # Check if there are missing dependencies

--- a/src/cli/ui.py
+++ b/src/cli/ui.py
@@ -5,8 +5,9 @@ import os
 import plistlib
 import subprocess
 import sys
-from src.info import name, version, os_ver, arch, color_text, format_text, surprise
+from src.info import name, version, arch, color_text, format_text, surprise
 from src.info import root_dir as root
+from src.util.os_version import os_ver
 from src.managers.tree import tree
 
 

--- a/src/info.py
+++ b/src/info.py
@@ -5,7 +5,6 @@ the UI functions.
 """
 
 import platform
-import distro
 import os
 
 name = "OCSysInfo"
@@ -41,50 +40,6 @@ def format_text(text, formatting):
     final_string += end_formatting
     return final_string
 
-
-version_dict = {
-    6: f"Mac OS X 10.2 {color_text('(Jaguar)', 'cyan')}",
-    7: f"Mac OS X 10.3 {color_text('(Panther)', 'cyan')}",
-    8: f"Mac OS X 10.4 {color_text('(Tiger)', 'cyan')}",
-    9: f"Mac OS X 10.5 {color_text('(Leopard)', 'cyan')}",
-    10: f"Mac OS X 10.6 {color_text('(Snow Leopard)', 'cyan')}",
-    11: f"Mac OS X 10.7 {color_text('(Lion)', 'cyan')}",
-    12: f"OS X 10.8 {color_text('(Mountain Lion)', 'cyan')}",
-    13: f"OS X 10.9 {color_text('(Mavericks)', 'cyan')}",
-    14: f"OS X 10.10 {color_text('(Yosemite)', 'cyan')}",
-    15: f"OS X 10.11 {color_text('(El Capitan)', 'cyan')}",
-    16: f"macOS 10.12 {color_text('(Sierra)', 'cyan')}",
-    17: f"macOS 10.13 {color_text('(High Sierra)', 'cyan')}",
-    18: f"macOS 10.14 {color_text('(Mojave)', 'cyan')}",
-    19: f"macOS 10.15 {color_text('(Catalina)', 'cyan')}",
-    20: f"macOS 11 {color_text('(Big Sur)', 'cyan')}",
-    21: f"macOS 12 {color_text('(Monterey)', 'cyan')}",
-}
-
-
-def macos_kernel_version(release_string=None):
-    """
-    Returns the version of the Mac OS X kernel.
-    """
-    if not release_string:
-        release_string = str(platform.release())
-    release_string = release_string.split(".")[0]
-
-    version_name = version_dict.get(
-        int(release_string),
-        color_text("Unknown", "cyan")
-        if int(release_string) > 21 or int(release_string) <= 0
-        else f"Mac OS X {color_text(f'(Kernel version: {release_string})', 'cyan')}",
-    )
-    return version_name
-
-
-if _platform == "darwin":
-    os_ver = macos_kernel_version()
-elif _platform == "windows":
-    os_ver = f"{platform.system()} ({platform.version()})"
-elif _platform == "linux":
-    os_ver = f"{distro.name()} ({distro.version()})"
 
 surprise = f"""{cyan}
  __     __            ______                    _    _____ _   

--- a/src/util/os_version.py
+++ b/src/util/os_version.py
@@ -1,0 +1,50 @@
+import distro
+import platform
+
+from src.info import color_text
+
+version_dict = {
+    6: f"Mac OS X 10.2 {color_text('(Jaguar)', 'cyan')}",
+    7: f"Mac OS X 10.3 {color_text('(Panther)', 'cyan')}",
+    8: f"Mac OS X 10.4 {color_text('(Tiger)', 'cyan')}",
+    9: f"Mac OS X 10.5 {color_text('(Leopard)', 'cyan')}",
+    10: f"Mac OS X 10.6 {color_text('(Snow Leopard)', 'cyan')}",
+    11: f"Mac OS X 10.7 {color_text('(Lion)', 'cyan')}",
+    12: f"OS X 10.8 {color_text('(Mountain Lion)', 'cyan')}",
+    13: f"OS X 10.9 {color_text('(Mavericks)', 'cyan')}",
+    14: f"OS X 10.10 {color_text('(Yosemite)', 'cyan')}",
+    15: f"OS X 10.11 {color_text('(El Capitan)', 'cyan')}",
+    16: f"macOS 10.12 {color_text('(Sierra)', 'cyan')}",
+    17: f"macOS 10.13 {color_text('(High Sierra)', 'cyan')}",
+    18: f"macOS 10.14 {color_text('(Mojave)', 'cyan')}",
+    19: f"macOS 10.15 {color_text('(Catalina)', 'cyan')}",
+    20: f"macOS 11 {color_text('(Big Sur)', 'cyan')}",
+    21: f"macOS 12 {color_text('(Monterey)', 'cyan')}",
+}
+
+_platform = platform.system().lower()
+
+
+def macos_kernel_version(release_string=None):
+    """
+    Returns the version of the Mac OS X kernel.
+    """
+    if not release_string:
+        release_string = str(platform.release())
+    release_string = release_string.split(".")[0]
+
+    version_name = version_dict.get(
+        int(release_string),
+        color_text("Unknown", "cyan")
+        if int(release_string) > 21 or int(release_string) <= 0
+        else f"Mac OS X {color_text(f'(Kernel version: {release_string})', 'cyan')}",
+    )
+    return version_name
+
+
+if _platform == "darwin":
+    os_ver = macos_kernel_version()
+elif _platform == "windows":
+    os_ver = f"{platform.system()} ({platform.version()})"
+elif _platform == "linux":
+    os_ver = f"{distro.name()} ({distro.version()})"


### PR DESCRIPTION
Needs more checking, as the functions responsible for detecting the host OS version was moved to another file.