### PR TITLE
Fix CPU info for ARM CPUs on Linux 

### DIFF
--- a/src/dumps/Linux/linux.py
+++ b/src/dumps/Linux/linux.py
@@ -41,11 +41,38 @@ class LinuxHardwareManager:
             )
             cpu_err(e)
 
+        architecture = subprocess.run(['uname', '-m'], capture_output=True, text=True)
+
+        if architecture.stdout == "aarch64\n" or "arm" in architecture.stdout: # Check if the architecture is ARM.
+            data = {}
+
+            model = re.search(r"(?<=Hardware\t\: ).+(?=\n)", cpus) # Get the name of the CPU.
+            arm_version = re.search(r"(?<=CPU architecture\: ).+(?=\n)", cpus) # Get the ARM version of the CPU
+            model = model.group()
+            data = {model: {}}
+
+            try:
+                # Count the amount of times 'processor'
+                # is matched, since threads are enumerated individually.
+                threads = cpus.count("processor")
+                data[model]["Threads"] = (threads)
+            except Exception as e:
+                self.logger.error(
+                    f"Failed to resolve thread count for {model} (PROC_FS)\n\t^^^^^^^^^{str(e)}",
+                    __file__,
+                )
+                pass
+
+            data[model]["ARM Version"] = arm_version.group()
+
+            self.info.get("CPU").append(data)
+            return
+        
         cpu = cpus.split("\n\n")
 
         if not cpu:
             return
-
+        
         cpu = cpu[0]  # Get only the first CPU identifier.
 
         model = re.search(r"(?<=model name\t\: ).+(?=\n)", cpu)


### PR DESCRIPTION
Fix for ARM cpus with linux

Current behavior
Exists because of the difference with /proc/cpuinfo on ARM CPUs

Proposed fix
Add a if block to check if the CPU is ARM

![Snímek obrazovky 2022-03-09 v 18 08 18](https://user-images.githubusercontent.com/62877244/157493674-957eb756-b940-473f-a925-df9b2204919a.png)

Ill try it on ARMv7, I just need to setup my old knock-off Pi 